### PR TITLE
feat: add player vitals parser and snapshot skeleton

### DIFF
--- a/hv_bie/__init__.py
+++ b/hv_bie/__init__.py
@@ -1,0 +1,37 @@
+"""HV-BIE public API."""
+
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+
+from hv_bie.types import (
+    AbilitiesState,
+    BattleSnapshot,
+    CombatLog,
+    ItemsState,
+    PlayerState,
+)
+from hv_bie.parsers.vitals import parse_vitals
+
+
+def parse_snapshot(html: str) -> BattleSnapshot:
+    """Parse one HentaiVerse battle HTML into a structured snapshot."""
+
+    soup = BeautifulSoup(html, "html.parser")
+    warnings: list[str] = []
+
+    player, player_warnings = parse_vitals(soup)
+    warnings.extend(player_warnings)
+
+    snapshot = BattleSnapshot(
+        player=player,
+        abilities=AbilitiesState(),
+        monsters=[],
+        log=CombatLog(),
+        items=ItemsState(),
+        warnings=warnings,
+    )
+    return snapshot
+
+
+__all__ = ["parse_snapshot", "BattleSnapshot", "PlayerState"]

--- a/hv_bie/parsers/__init__.py
+++ b/hv_bie/parsers/__init__.py
@@ -1,0 +1,5 @@
+"""Parsers package."""
+
+from .vitals import parse_vitals
+
+__all__ = ["parse_vitals"]

--- a/hv_bie/parsers/vitals.py
+++ b/hv_bie/parsers/vitals.py
@@ -1,0 +1,81 @@
+"""Player vitals parser."""
+
+from __future__ import annotations
+
+from bs4 import BeautifulSoup
+import re
+from typing import Tuple
+
+from hv_bie.types import PlayerState
+
+BAR_IDS = {
+    "hp": "dvbh",
+    "mp": "dvbm",
+    "sp": "dvbs",
+    "oc": "dvbc",
+}
+
+VALUE_IDS = {
+    "hp": "dvrhd",
+    "mp": "dvrm",
+    "sp": "dvrs",
+    "oc": "dvrc",
+}
+
+MAX_WIDTH = 414
+
+
+def _extract_width(node: BeautifulSoup) -> float | None:
+    """Extract width in pixels from style attribute."""
+
+    if not node:
+        return None
+    style = node.get("style", "")
+    match = re.search(r"width:(\d+)px", style)
+    if match:
+        return float(match.group(1))
+    return None
+
+
+def parse_vitals(soup: BeautifulSoup) -> Tuple[PlayerState, list[str]]:
+    """Parse player vitals from soup.
+
+    Returns the parsed ``PlayerState`` and a list of warning messages.
+    """
+
+    warnings: list[str] = []
+
+    def get_value(key: str) -> int:
+        div = soup.find(id=VALUE_IDS[key])
+        if div and div.text.strip().isdigit():
+            return int(div.text.strip())
+        warnings.append(f"missing {key} value")
+        return 0
+
+    def get_percent(key: str) -> float:
+        img = soup.select_one(f"#{BAR_IDS[key]} img")
+        width = _extract_width(img)
+        if width is None:
+            warnings.append(f"missing {key} bar")
+            return 0.0
+        return max(0.0, min(100.0, width / MAX_WIDTH * 100))
+
+    hp_val = get_value("hp")
+    mp_val = get_value("mp")
+    sp_val = get_value("sp")
+    oc_val = get_value("oc")
+
+    player = PlayerState(
+        hp_percent=get_percent("hp"),
+        hp_value=hp_val,
+        mp_percent=get_percent("mp"),
+        mp_value=mp_val,
+        sp_percent=get_percent("sp"),
+        sp_value=sp_val,
+        overcharge_value=oc_val,
+    )
+
+    return player, warnings
+
+
+__all__ = ["parse_vitals"]

--- a/hv_bie/types/__init__.py
+++ b/hv_bie/types/__init__.py
@@ -1,0 +1,134 @@
+"""Data models for HV-BIE.
+
+Public dataclasses representing parsed battle data.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field, asdict
+import json
+
+
+@dataclass
+class Buff:
+    """Status effect on player or monster."""
+
+    name: str
+    remaining_seconds: float | None
+    is_permanent: bool
+
+
+@dataclass
+class Ability:
+    """Action available to the player."""
+
+    name: str
+    available: bool
+    cost: float | None
+    cost_type: str | None
+    cooldown_seconds: float | None
+
+
+@dataclass
+class AbilitiesState:
+    """Grouping of skills and spells."""
+
+    skills: list[Ability] = field(default_factory=list)
+    spells: list[Ability] = field(default_factory=list)
+
+
+@dataclass
+class Monster:
+    """Enemy monster shown on the battlefield."""
+
+    slot_index: int
+    name: str
+    alive: bool
+    system_monster_type: str | None
+    hp_percent: float
+    mp_percent: float
+    sp_percent: float
+    buffs: list[Buff] = field(default_factory=list)
+
+
+@dataclass
+class CombatLog:
+    """Combat text lines and round info."""
+
+    lines: list[str] = field(default_factory=list)
+    current_round: int | None = None
+    total_round: int | None = None
+
+
+@dataclass
+class Item:
+    """Item shown in battle."""
+
+    slot: str | int
+    name: str
+
+
+@dataclass
+class QuickSlot:
+    """Quickbar slot item."""
+
+    slot: str | int
+    name: str
+
+
+@dataclass
+class ItemsState:
+    """Items and quickbar grouping."""
+
+    items: list[Item] = field(default_factory=list)
+    quickbar: list[QuickSlot] = field(default_factory=list)
+
+
+@dataclass
+class PlayerState:
+    """Player resource vitals and buffs."""
+
+    hp_percent: float
+    hp_value: int
+    mp_percent: float
+    mp_value: int
+    sp_percent: float
+    sp_value: int
+    overcharge_value: int
+    buffs: list[Buff] = field(default_factory=list)
+
+
+@dataclass
+class BattleSnapshot:
+    """Aggregated view of one battle page."""
+
+    player: PlayerState
+    abilities: AbilitiesState
+    monsters: list[Monster]
+    log: CombatLog
+    items: ItemsState
+    warnings: list[str] = field(default_factory=list)
+
+    def as_dict(self) -> dict:
+        """Return a ``dict`` representation of the snapshot."""
+
+        return asdict(self)
+
+    def to_json(self) -> str:
+        """Serialize the snapshot to JSON."""
+
+        return json.dumps(self.as_dict())
+
+
+__all__ = [
+    "Buff",
+    "Ability",
+    "AbilitiesState",
+    "Monster",
+    "CombatLog",
+    "Item",
+    "QuickSlot",
+    "ItemsState",
+    "PlayerState",
+    "BattleSnapshot",
+]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,11 @@
+[project]
+name = "hv-bie"
+version = "0.1.0"
+description = "HentaiVerse battle information extractor"
+authors = [{name = "HV-BIE"}]
+requires-python = ">=3.13"
+dependencies = ["beautifulsoup4"]
+
+[build-system]
+requires = ["setuptools>=61.0"]
+build-backend = "setuptools.build_meta"

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,17 @@
+import pathlib
+import sys
+import pytest
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(ROOT))
+FIXTURES = ROOT / "tests" / "fixtures" / "hv"
+
+
+@pytest.fixture
+def hv_html_loader():
+    """Load HV sample HTML by name."""
+
+    def loader(name: str) -> str:
+        return (FIXTURES / f"{name}.htm").read_text(encoding="utf-8")
+
+    return loader

--- a/tests/test_parse_vitals.py
+++ b/tests/test_parse_vitals.py
@@ -1,0 +1,18 @@
+from bs4 import BeautifulSoup
+
+from hv_bie.parsers import parse_vitals
+
+
+def test_vitals_parses_percent_and_values(hv_html_loader):
+    html = hv_html_loader("The HentaiVerse")
+    soup = BeautifulSoup(html, "html.parser")
+    player, warnings = parse_vitals(soup)
+
+    assert player.hp_value == 23618
+    assert player.mp_value == 1595
+    assert player.sp_value == 1317
+    assert player.overcharge_value == 0
+    assert player.hp_percent == 100.0
+    assert player.mp_percent == 100.0
+    assert player.sp_percent == 100.0
+    assert warnings == []

--- a/tests/test_snapshot_integration.py
+++ b/tests/test_snapshot_integration.py
@@ -1,0 +1,13 @@
+from hv_bie import parse_snapshot
+from hv_bie.types import BattleSnapshot
+
+
+def test_snapshot_integration_basic(hv_html_loader):
+    html = hv_html_loader("The HentaiVerse")
+    snapshot = parse_snapshot(html)
+
+    assert isinstance(snapshot, BattleSnapshot)
+    assert snapshot.player.hp_value == 23618
+    assert snapshot.player.mp_percent == 100.0
+    assert snapshot.abilities.skills == []
+    assert snapshot.warnings == []


### PR DESCRIPTION
## Summary
- define dataclasses for battle snapshot structures
- implement vitals parser and snapshot assembly
- cover vitals parsing with unit and integration tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_689e3328e384832797b599b1ddcddfe7